### PR TITLE
Add text shadow to carousel, fixes #17

### DIFF
--- a/src/components/Hero/_hero.scss
+++ b/src/components/Hero/_hero.scss
@@ -9,3 +9,7 @@
   width: inherit;
   height: inherit;
 }
+
+.text-shadow {
+  text-shadow: 0 0 1rem black;
+}

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -26,8 +26,8 @@ const Hero = () => {
                 />
               </Container>
               <Carousel.Caption>
-                <h1>{hero.label}</h1>
-                <p className="fs-4">{hero.summary}</p>
+                <h1 className="text-shadow">{hero.label}</h1>
+                <p className="fs-4 text-shadow">{hero.summary}</p>
                 {/*<Link to={hero.buttonLink} className="px-3 btn btn-dark">*/}
                 {/*  <span className="me-1">{hero.buttonText}</span>*/}
                 {/*  <ChevronRightIcon />*/}


### PR DESCRIPTION
Added a light shadow to the carousel caption elements on the Hero component. The shadow was added using custom css since bootstrap do not includes shadow effects for text.

Another alternative to this issue could be the one presented is this article about hero sections:
> [Inside the mind of a frontend developer: Hero section](https://ishadeed.com/article/inside-frontend-developer-mind-hero-section/).
That is: partially covering the hero section  where the text is displayed.

A discussion about the best choice can be discussed in further meetings and implemented later. The current implementation offers a good fix, at least for temporary one.