### PR TITLE
Fix sign-up covered page and form spacing, fix #20

### DIFF
--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -104,7 +104,7 @@ const SignIn = () => {
       <Row className="p-0 m-0">
         <Col className="p-0 m-0">
           <Container
-            className={`bg-light overflow-hidden ${breakpoint === "xs" || breakpoint === "sm" || breakpoint === "md" ? "min-vw-100 min-vh-100" : "rounded-3 signin-page__form-ctn"}`}
+            className={`bg-light overflow-hidden ${breakpoint === "xs" || breakpoint === "sm" || breakpoint === "md" ? "min-vw-100 min-vh-100" : "rounded-3 signin-page__form-ctn my-3"}`}
           >
             <Formik
               validationSchema={userSchema}

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -90,9 +90,9 @@ const SignUp = () => {
   return (
     <Container
       fluid
-      className="d-flex justify-content-center align-items-center vh-100 signup-page__ctn"
+      className="d-flex justify-content-center align-items-center min-vh-100 signup-page__ctn"
     >
-      <Container className="signup-page__form-ctn bg-light rounded-3">
+      <Container className="signup-page__form-ctn bg-light rounded-3 my-3">
         <Formik
           validationSchema={userSchema}
           initialValues={initialValues}


### PR DESCRIPTION
- Replaced Bootstrap class `vh-100` with `min-vh-100` to prevent the top and bottom sections of the Sign-Up page from being cut off on smaller screens. These sections were not accessible by scrolling. (Fixes #20)
- Added vertical margin to the form containers on both Sign-Up and Sign-In pages to improve visual balance and spacing.