### PR TITLE
fix(ui): correct favicon path for all routes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,11 @@
   user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
 -->
     <link href="%PUBLIC_URL%/manifest.json" rel="manifest" />
-    <link rel="icon" href="FEM_monocromatica.png" type="image/x-icon" />
+    <link
+      rel="icon"
+      href="%PUBLIC_URL%/FEM_monocromatica.png"
+      type="image/png"
+    />
     <!--
   Notice the use of %PUBLIC_URL% in the tags above.
   It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
The favicon was using a relative path in , which caused it to fail on nested client-side routes.

This change updates the  attribute to use the  variable, ensuring an absolute path is always generated and the favicon remains visible across the entire application.

fixes #24